### PR TITLE
feat(ci): add Discord notifications for PR events

### DIFF
--- a/.github/workflows/discord_notification.yml
+++ b/.github/workflows/discord_notification.yml
@@ -11,7 +11,7 @@ jobs:
 
         steps:
             -   name: Send PR Opened Notification
-                if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+                if: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened') }}
                 uses: Ilshidur/action-discord@0.3.2
                 env:
                     DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_APP_PR }}

--- a/.github/workflows/discord_notification.yml
+++ b/.github/workflows/discord_notification.yml
@@ -1,0 +1,67 @@
+name: Discord Notifications
+
+on:
+    pull_request:
+        types: [ opened, reopened, closed ]
+
+jobs:
+    notify:
+        name: Discord Notification
+        runs-on: ubuntu-latest
+
+        steps:
+            -   name: Send PR Opened Notification
+                if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+                uses: Ilshidur/action-discord@0.3.2
+                env:
+                    DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_APP_PR }}
+                    DISCORD_USERNAME: GitHub
+                    DISCORD_AVATAR: https://github.com/user-attachments/assets/f48ce758-689e-4e2c-8cba-d9397905c90f
+                    DISCORD_EMBEDS: |
+                        [
+                          {
+                            "title": "새로운 PR이 생성되었다냥 🚀\n${{ github.event.pull_request.title }}",
+                            "color": 5763719,
+                            "description": "${{ github.event.pull_request.html_url }}",
+                            "fields": [
+                              {
+                                "name": "PR Number",
+                                "value": "#${{ github.event.pull_request.number }}",
+                                "inline": true
+                              },
+                              {
+                                "name": "Author",
+                                "value": "${{ github.event.pull_request.user.login }}",
+                                "inline": true
+                              }
+                            ]
+                          }
+                        ]
+
+            -   name: Send PR Merged Notification
+                if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true }}
+                uses: Ilshidur/action-discord@0.3.2
+                env:
+                    DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_APP_PR }}
+                    DISCORD_USERNAME: GitHub
+                    DISCORD_AVATAR: https://github.com/user-attachments/assets/f48ce758-689e-4e2c-8cba-d9397905c90f
+                    DISCORD_EMBEDS: |
+                        [
+                          {
+                            "title": "PR이 머지되었다냥 🎉\n${{ github.event.pull_request.title }}",
+                            "color": 15844367,
+                            "description": "${{ github.event.pull_request.html_url }}",
+                            "fields": [
+                              {
+                                "name": "PR Number",
+                                "value": "#${{ github.event.pull_request.number }}",
+                                "inline": true
+                              },
+                              {
+                                "name": "Merged by",
+                                "value": "${{ github.event.sender.login }}",
+                                "inline": true
+                              }
+                            ]
+                          }
+                        ]


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

- notify when new pr is opened or merged to this repository.

## Does this close any currently open issues?

…

## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
...

## Any other comments?

…
