### PR TITLE
chore(ci): add discord notification on workflow failure

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -67,3 +67,31 @@ jobs:
             **/build/compose-metrics
             **/build/compose-reports
           retention-days: 7
+
+      - name: Notify Failure on Discord
+        if: ${{ failure() }}
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_APP_CI }}
+          DISCORD_USERNAME: CI_CAT
+          DISCORD_AVATAR: https://github.com/user-attachments/assets/f4a333ae-c6e0-43ed-abe7-4e50a519a3be
+          DISCORD_EMBEDS: |
+            [
+              {
+                "title": "빌드 실패했다냥 ❌",
+                "color": 15158332,
+                "description": "[#${{ github.event.pull_request.number }}] ${{ github.event.pull_request.title }}\n${{ github.event.pull_request.html_url }}",
+                "fields": [
+                  {
+                    "name": "브랜치",
+                    "value": "${{ github.ref }}",
+                    "inline": true
+                  },
+                  {
+                    "name": "작성자",
+                    "value": "${{ github.event.pull_request.user.login }}",
+                    "inline": true
+                  }
+                ]
+              }
+            ]


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

- notify ci failure to discord

## Does this close any currently open issues?

…

## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
...

## Any other comments?

…
