### PR TITLE
fix: fix content color for Naver OAuth button

### DIFF
--- a/features/auth/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/auth/presentation/login/components/OauthButton.kt
+++ b/features/auth/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/auth/presentation/login/components/OauthButton.kt
@@ -37,7 +37,7 @@ internal fun NaverOAuthButton(
         text = Res.string.login_naver_oauth_button,
         colors = ButtonColors(
             containerColor = Color(0xFF03C75A),
-            contentColor = SoomjaeTheme.colorScheme.text1,
+            contentColor = SoomjaeTheme.colorScheme.text1W,
             disabledContainerColor = Color.Unspecified,
             disabledContentColor = Color.Unspecified,
         ),


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

- fix content color for Naver OAuth button

## Does this close any currently open issues?

…

## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
...

## Any other comments?

…
