### PR TITLE
refactor(posts): move meeting tab to its own module

### DIFF
--- a/core/presentation/designsystem/src/commonMain/kotlin/com/parksupark/soomjae/core/presentation/designsystem/components/Button.kt
+++ b/core/presentation/designsystem/src/commonMain/kotlin/com/parksupark/soomjae/core/presentation/designsystem/components/Button.kt
@@ -3,7 +3,6 @@ package com.parksupark.soomjae.core.presentation.designsystem.components
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues

--- a/core/presentation/designsystem/src/commonMain/kotlin/com/parksupark/soomjae/core/presentation/designsystem/theme/ColorExts.kt
+++ b/core/presentation/designsystem/src/commonMain/kotlin/com/parksupark/soomjae/core/presentation/designsystem/theme/ColorExts.kt
@@ -1,0 +1,26 @@
+package com.parksupark.soomjae.core.presentation.designsystem.theme
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+@Composable
+private fun extendedColor(
+    light: Color,
+    dark: Color,
+): Color = if (LocalThemeIsDark.current.value) {
+    dark
+} else {
+    light
+}
+
+val SoomjaeColors.like: Color
+    @Composable get() = extendedColor(
+        light = Red400,
+        dark = Red200,
+    )
+
+val SoomjaeColors.comment: Color
+    @Composable get() = extendedColor(
+        light = Green400,
+        dark = Green200,
+    )

--- a/core/presentation/ui/src/commonMain/kotlin/com/parksupark/soomjae/core/presentation/ui/utils/DensityUtils.kt
+++ b/core/presentation/ui/src/commonMain/kotlin/com/parksupark/soomjae/core/presentation/ui/utils/DensityUtils.kt
@@ -1,0 +1,11 @@
+package com.parksupark.soomjae.core.presentation.ui.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
+
+@Composable
+fun TextUnit.toDp(): Dp = with(LocalDensity.current) {
+    toDp()
+}

--- a/features/posts/aggregate/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/aggregate/presentation/di/FeaturesPostPresentationModule.kt
+++ b/features/posts/aggregate/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/aggregate/presentation/di/FeaturesPostPresentationModule.kt
@@ -1,9 +1,10 @@
 package com.parksupark.soomjae.features.posts.aggregate.presentation.di
 
 import com.parksupark.soomjae.features.posts.aggregate.presentation.post.PostViewModel
-import com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting.MeetingTabViewModel
 import com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.member.MemberTabViewModel
 import com.parksupark.soomjae.features.posts.common.presentation.di.featuresPostsCommonPresentationModule
+import com.parksupark.soomjae.features.posts.common.presentation.di.featuresPostsMeetingPresentationModule
+import com.parksupark.soomjae.features.posts.common.presentation.tab.MeetingTabViewModel
 import com.parksupark.soomjae.features.posts.community.presentation.di.featuresPostsCommunityPresentationModule
 import org.koin.core.module.dsl.viewModelOf
 import org.koin.dsl.module
@@ -17,5 +18,5 @@ private val postModule = module {
 
 val featuresPostsAggregatePresentationModule = module {
     includes(postModule)
-    includes(featuresPostsCommonPresentationModule, featuresPostsCommunityPresentationModule)
+    includes(featuresPostsCommonPresentationModule, featuresPostsCommunityPresentationModule, featuresPostsMeetingPresentationModule)
 }

--- a/features/posts/aggregate/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/aggregate/presentation/post/PostScreen.kt
+++ b/features/posts/aggregate/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/aggregate/presentation/post/PostScreen.kt
@@ -18,13 +18,13 @@ import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeS
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeTab
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeTabRow
 import com.parksupark.soomjae.core.presentation.ui.resources.value
-import com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting.MeetingTabRoute
 import com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.member.MemberTabRoute
 import com.parksupark.soomjae.features.posts.aggregate.presentation.resources.Res
 import com.parksupark.soomjae.features.posts.aggregate.presentation.resources.post_community_title
 import com.parksupark.soomjae.features.posts.aggregate.presentation.resources.post_feed_title
 import com.parksupark.soomjae.features.posts.aggregate.presentation.resources.post_meeting_title
 import com.parksupark.soomjae.features.posts.common.presentation.PostAction
+import com.parksupark.soomjae.features.posts.common.presentation.tab.MeetingTabRoute
 import com.parksupark.soomjae.features.posts.community.presentation.tab.CommunityTabRoute
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource

--- a/features/posts/common/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/WritePostFabPreview.kt
+++ b/features/posts/common/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/WritePostFabPreview.kt
@@ -1,0 +1,23 @@
+package com.parksupark.soomjae.features.posts.common.presentation.previews
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeSurface
+import com.parksupark.soomjae.core.presentation.designsystem.theme.AppTheme
+import com.parksupark.soomjae.features.posts.common.presentation.components.WritePostFab
+
+@Preview
+@Composable
+private fun WritePostFabPreview() {
+    AppTheme {
+        SoomjaeSurface {
+            WritePostFab(
+                onClick = { },
+                modifier = Modifier.padding(4.dp),
+            )
+        }
+    }
+}

--- a/features/posts/common/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/providers/CategoryUiPreviewParametersProvider.kt
+++ b/features/posts/common/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/providers/CategoryUiPreviewParametersProvider.kt
@@ -1,0 +1,96 @@
+package com.parksupark.soomjae.features.posts.common.presentation.previews.providers
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.parksupark.soomjae.features.posts.common.domain.models.Category
+import com.parksupark.soomjae.features.posts.common.presentation.models.CategoryUi
+import com.parksupark.soomjae.features.posts.common.presentation.models.toUi
+import com.parksupark.soomjae.features.posts.common.presentation.previews.providers.CategoryUiPreviewParameterData.categories
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+
+class CategoryUiPreviewParametersProvider : PreviewParameterProvider<ImmutableList<CategoryUi>> {
+    override val values: Sequence<ImmutableList<CategoryUi>> = sequenceOf(categories.map { it.toUi() }.toImmutableList())
+}
+
+object CategoryUiPreviewParameterData {
+    val categories = persistentListOf(
+        Category(
+            id = 1L,
+            name = "Android",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 2L,
+            name = "iOS",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 3L,
+            name = "Web",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 4L,
+            name = "Backend",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 5L,
+            name = "DevOps",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 6L,
+            name = "AI",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 7L,
+            name = "Cloud",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 8L,
+            name = "Security",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 9L,
+            name = "Data Science",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 10L,
+            name = "Game Development",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+        Category(
+            id = 11L,
+            name = "UI/UX",
+            hierarchy = 1,
+            children = emptyList(),
+            parentId = null,
+        ),
+    )
+}

--- a/features/posts/common/presentation/src/commonMain/composeResources/values/strings.xml
+++ b/features/posts/common/presentation/src/commonMain/composeResources/values/strings.xml
@@ -1,4 +1,6 @@
 <resources>
     <string name="write_input_title_placeholder">제목 입력란</string>
     <string name="write_input_content_placeholder">내용을 입력하세요.</string>
+
+    <string name="write_post_button">글 쓰기</string>
 </resources>

--- a/features/posts/common/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/components/WritePostFab.kt
+++ b/features/posts/common/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/components/WritePostFab.kt
@@ -1,0 +1,46 @@
+package com.parksupark.soomjae.features.posts.common.presentation.components
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeButton
+import com.parksupark.soomjae.core.presentation.designsystem.theme.SoomjaeTheme
+import com.parksupark.soomjae.core.presentation.designsystem.theme.like
+
+@Composable
+fun WritePostFab(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SoomjaeButton(
+        modifier = modifier,
+        onClick = onClick,
+        shape = MaterialTheme.shapes.extraLarge,
+        border = BorderStroke(
+            width = 1.dp,
+            color = SoomjaeTheme.colorScheme.text4,
+        ),
+        background = SoomjaeTheme.colorScheme.background2,
+        contentColor = SoomjaeTheme.colorScheme.text1,
+        contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Edit,
+            contentDescription = null,
+            tint = SoomjaeTheme.colorScheme.like,
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "글 쓰기",
+        )
+    }
+}

--- a/features/posts/common/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/components/WritePostFab.kt
+++ b/features/posts/common/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/components/WritePostFab.kt
@@ -15,6 +15,9 @@ import androidx.compose.ui.unit.dp
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeButton
 import com.parksupark.soomjae.core.presentation.designsystem.theme.SoomjaeTheme
 import com.parksupark.soomjae.core.presentation.designsystem.theme.like
+import com.parksupark.soomjae.core.presentation.ui.resources.value
+import com.parksupark.soomjae.features.posts.common.presentation.resources.Res
+import com.parksupark.soomjae.features.posts.common.presentation.resources.write_post_button
 
 @Composable
 fun WritePostFab(
@@ -39,8 +42,6 @@ fun WritePostFab(
             tint = SoomjaeTheme.colorScheme.like,
         )
         Spacer(modifier = Modifier.width(8.dp))
-        Text(
-            text = "글 쓰기",
-        )
+        Text(text = Res.string.write_post_button.value)
     }
 }

--- a/features/posts/community/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/community/presentation/tab/CommunityTabScreen.kt
+++ b/features/posts/community/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/community/presentation/tab/CommunityTabScreen.kt
@@ -5,10 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -16,20 +13,18 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import app.cash.paging.LoadStateError
 import app.cash.paging.LoadStateLoading
 import app.cash.paging.LoadStateNotLoading
 import app.cash.paging.compose.LazyPagingItems
 import app.cash.paging.compose.itemKey
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeCircularProgressIndicator
-import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeFab
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeHorizontalDivider
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaePullToRefreshBox
 import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeScaffold
-import com.parksupark.soomjae.core.presentation.ui.resources.value
+import com.parksupark.soomjae.features.posts.common.presentation.components.WritePostFab
 import com.parksupark.soomjae.features.posts.community.presentation.models.CommunityPostUi
-import com.parksupark.soomjae.features.posts.community.presentation.resources.Res
-import com.parksupark.soomjae.features.posts.community.presentation.resources.post_community_fab_description
 import com.parksupark.soomjae.features.posts.community.presentation.tab.components.CommunityPostCard
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -48,20 +43,13 @@ internal fun CommunityTabScreen(
         }
     }
 
-    SoomjaeScaffold(
-        floatingActionButton = {
-            SoomjaeFab(
-                onClick = { onAction(CommunityTabAction.OnCommunityWriteClick) },
-                content = { Icon(Icons.Outlined.Edit, contentDescription = Res.string.post_community_fab_description.value) },
-            )
-        },
-    ) { innerPadding ->
+    SoomjaeScaffold(modifier = Modifier.fillMaxSize()) { _ ->
         val isRefreshing = state.isPostsRefreshing && posts.loadState.refresh is LoadStateLoading
 
         SoomjaePullToRefreshBox(
             isRefreshing = isRefreshing,
             onRefresh = { onAction(CommunityTabAction.OnPullToRefresh) },
-            modifier = Modifier.fillMaxSize().padding(innerPadding),
+            modifier = Modifier.fillMaxSize(),
         ) {
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
@@ -93,6 +81,11 @@ internal fun CommunityTabScreen(
                     }
                 }
             }
+
+            WritePostFab(
+                modifier = Modifier.align(Alignment.BottomCenter).padding(bottom = 8.dp),
+                onClick = { onAction(CommunityTabAction.OnCommunityWriteClick) },
+            )
         }
     }
 }

--- a/features/posts/meeting/domain/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/domain/models/MeetingPost.kt
+++ b/features/posts/meeting/domain/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/domain/models/MeetingPost.kt
@@ -1,0 +1,15 @@
+package com.parksupark.soomjae.features.posts.common.domain.models
+
+import com.parksupark.soomjae.core.domain.models.Member
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+data class MeetingPost(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val createdAt: Instant,
+    val author: Member,
+    val category: Category,
+)

--- a/features/posts/meeting/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/MeetingTab.kt
+++ b/features/posts/meeting/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/MeetingTab.kt
@@ -1,10 +1,10 @@
-package com.parksupark.soomjae.features.posts.aggregate.presentation.previews
+package com.parksupark.soomjae.features.posts.common.presentation.previews
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.parksupark.soomjae.core.presentation.designsystem.theme.AppTheme
-import com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting.MeetingTabScreen
-import com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting.MeetingTabState
+import com.parksupark.soomjae.features.posts.common.presentation.tab.MeetingTabScreen
+import com.parksupark.soomjae.features.posts.common.presentation.tab.MeetingTabState
 
 @Composable
 @Preview(name = "MeetingTab")
@@ -12,7 +12,7 @@ private fun MeetingTabScreenPreview() {
     AppTheme {
         MeetingTabScreen(
             state = MeetingTabState(),
-            onAction = {},
+            onAction = { },
         )
     }
 }

--- a/features/posts/meeting/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/components/MeetingPostCardPreview.kt
+++ b/features/posts/meeting/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/components/MeetingPostCardPreview.kt
@@ -1,0 +1,22 @@
+package com.parksupark.soomjae.features.posts.common.presentation.previews.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.parksupark.soomjae.core.presentation.designsystem.theme.AppTheme
+import com.parksupark.soomjae.features.posts.common.presentation.previews.providers.MeetingPostUiPreviewParameterProvider
+import com.parksupark.soomjae.features.posts.common.presentation.tab.components.MeetingPostCard
+import com.parksupark.soomjae.features.posts.common.presentation.tab.models.MeetingPostUi
+import kotlinx.collections.immutable.ImmutableList
+
+@PreviewLightDark
+@Composable
+private fun MeetingPostCardPreview(
+    @PreviewParameter(MeetingPostUiPreviewParameterProvider::class) posts: ImmutableList<MeetingPostUi>,
+) {
+    AppTheme {
+        MeetingPostCard(
+            post = posts.first(),
+        )
+    }
+}

--- a/features/posts/meeting/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/providers/MeetingPostUiPreviewParameterProvider.kt
+++ b/features/posts/meeting/presentation/src/androidMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/previews/providers/MeetingPostUiPreviewParameterProvider.kt
@@ -1,0 +1,57 @@
+package com.parksupark.soomjae.features.posts.common.presentation.previews.providers
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.parksupark.soomjae.core.presentation.ui.previews.proviers.MemberPreviewParameterData.members
+import com.parksupark.soomjae.features.posts.common.domain.models.MeetingPost
+import com.parksupark.soomjae.features.posts.common.presentation.previews.providers.CategoryUiPreviewParameterData.categories
+import com.parksupark.soomjae.features.posts.common.presentation.previews.providers.MeetingPostPreviewParameterData.posts
+import com.parksupark.soomjae.features.posts.common.presentation.tab.models.MeetingPostUi
+import com.parksupark.soomjae.features.posts.common.presentation.tab.models.toMeetingPostUi
+import kotlin.time.ExperimentalTime
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toInstant
+
+@OptIn(ExperimentalTime::class)
+internal class MeetingPostUiPreviewParameterProvider : PreviewParameterProvider<ImmutableList<MeetingPostUi>> {
+    override val values: Sequence<ImmutableList<MeetingPostUi>> = sequenceOf(posts.map { it.toMeetingPostUi() }.toImmutableList())
+}
+
+@Suppress("ktlint:standard:max-line-length")
+@OptIn(ExperimentalTime::class)
+object MeetingPostPreviewParameterData {
+    val posts = persistentListOf(
+        MeetingPost(
+            id = 1L,
+            title = "Android Study Group Kick-off",
+            content = "Let's start our Android study group! We'll discuss the basics of Kotlin and Jetpack Compose. Bring your laptops and enthusiasm!",
+            createdAt = LocalDateTime(2023, 1, 1, 10, 15, 30).toInstant(TimeZone.UTC),
+            author = members[0],
+            category = categories[0],
+        ),
+        MeetingPost(
+            id = 2L,
+            title = "Deep Dive into Coroutines",
+            content = "This session will focus on Kotlin Coroutines. We'll explore structured concurrency, dispatchers, and error handling. Recommended for intermediate developers.",
+            createdAt = LocalDateTime(2023, 1, 5, 14, 20, 5).toInstant(TimeZone.UTC),
+            author = members[1],
+            category = categories[1],
+        ),
+        MeetingPost(
+            id = 3L,
+            title = "Jetpack Compose UI Workshop",
+            content =
+                """
+                Join us for a hands-on workshop on building beautiful UIs with Jetpack Compose.
+                We will cover layouts, state management, and theming.
+                Please install Android Studio Bumblebee or later.
+                """.trimIndent(),
+            createdAt = LocalDateTime(2023, 1, 10, 9, 45, 55).toInstant(TimeZone.UTC),
+            author = members[2],
+            category = categories[2],
+        ),
+    )
+}

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/di/FeaturesPostsMeetingPresentationModule.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/di/FeaturesPostsMeetingPresentationModule.kt
@@ -1,0 +1,13 @@
+package com.parksupark.soomjae.features.posts.common.presentation.di
+
+import com.parksupark.soomjae.features.posts.common.presentation.tab.MeetingTabViewModel
+import org.koin.core.module.dsl.viewModelOf
+import org.koin.dsl.module
+
+private val tabModule = module {
+    viewModelOf(::MeetingTabViewModel)
+}
+
+val featuresPostsMeetingPresentationModule = module {
+    includes(tabModule)
+}

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabContract.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabContract.kt
@@ -1,4 +1,4 @@
-package com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting
+package com.parksupark.soomjae.features.posts.common.presentation.tab
 
 class MeetingTabState
 

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabCoordinator.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabCoordinator.kt
@@ -1,4 +1,4 @@
-package com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting
+package com.parksupark.soomjae.features.posts.common.presentation.tab
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabRoute.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabRoute.kt
@@ -1,4 +1,4 @@
-package com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting
+package com.parksupark.soomjae.features.posts.common.presentation.tab
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabScreen.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabScreen.kt
@@ -1,4 +1,4 @@
-package com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting
+package com.parksupark.soomjae.features.posts.common.presentation.tab
 
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabViewModel.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/MeetingTabViewModel.kt
@@ -1,14 +1,11 @@
-package com.parksupark.soomjae.features.posts.aggregate.presentation.post.tabs.meeting
+package com.parksupark.soomjae.features.posts.common.presentation.tab
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class MeetingTabViewModel(
-    savedStateHandle: SavedStateHandle,
-) : ViewModel() {
+class MeetingTabViewModel : ViewModel() {
     private val _stateFlow: MutableStateFlow<MeetingTabState> = MutableStateFlow(MeetingTabState())
     val stateFlow: StateFlow<MeetingTabState> = _stateFlow.asStateFlow()
 }

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/components/MeetingPostCard.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/components/MeetingPostCard.kt
@@ -1,0 +1,161 @@
+package com.parksupark.soomjae.features.posts.common.presentation.tab.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.Comment
+import androidx.compose.material.icons.outlined.ThumbUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeSurface
+import com.parksupark.soomjae.core.presentation.designsystem.components.SoomjaeVerticalDivider
+import com.parksupark.soomjae.core.presentation.designsystem.theme.SoomjaeTheme
+import com.parksupark.soomjae.core.presentation.designsystem.theme.comment
+import com.parksupark.soomjae.core.presentation.designsystem.theme.like
+import com.parksupark.soomjae.core.presentation.ui.utils.toDp
+import com.parksupark.soomjae.features.posts.common.presentation.models.CategoryUi
+import com.parksupark.soomjae.features.posts.common.presentation.tab.models.MeetingPostUi
+
+@Composable
+internal fun MeetingPostCard(
+    post: MeetingPostUi,
+    modifier: Modifier = Modifier,
+) {
+    SoomjaeSurface(modifier = modifier) {
+        Column(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            PostCardHeader(category = post.category)
+
+            PostCardTitle(title = post.title)
+
+            PostCardContent(content = post.content)
+
+            PostCardAdditionalInfos(
+                likeCount = post.likeCount,
+                commentCount = post.commentCount,
+                createdAt = post.formattedCreatedAt,
+                author = post.author.nickname,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PostCardHeader(category: CategoryUi) {
+    Text(
+        text = category.name,
+        style = SoomjaeTheme.typography.captionS,
+        color = SoomjaeTheme.colorScheme.text3,
+        modifier = Modifier.background(
+            color = SoomjaeTheme.colorScheme.background3,
+            shape = MaterialTheme.shapes.extraSmall,
+        ).padding(
+            horizontal = 8.dp,
+            vertical = 4.dp,
+        ),
+    )
+}
+
+@Composable
+private fun PostCardTitle(title: String) {
+    Text(text = title, style = SoomjaeTheme.typography.title3, maxLines = 1)
+}
+
+@Composable
+private fun PostCardContent(
+    content: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = content,
+        style = SoomjaeTheme.typography.captionL,
+        maxLines = 2,
+        modifier = modifier,
+        overflow = TextOverflow.Ellipsis,
+    )
+}
+
+@Composable
+private fun PostCardAdditionalInfos(
+    likeCount: Int,
+    commentCount: Int,
+    createdAt: String,
+    author: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        val height = SoomjaeTheme.typography.captionS.fontSize.toDp()
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.ThumbUp,
+                contentDescription = null,
+                modifier = Modifier.size(height),
+                tint = SoomjaeTheme.colorScheme.like,
+            )
+            Text(
+                text = likeCount.toString(),
+                style = SoomjaeTheme.typography.captionS,
+                color = SoomjaeTheme.colorScheme.like,
+            )
+        }
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Outlined.Comment,
+                contentDescription = null,
+                modifier = Modifier.size(height),
+                tint = SoomjaeTheme.colorScheme.comment,
+            )
+            Text(
+                text = commentCount.toString(),
+                style = SoomjaeTheme.typography.captionS,
+                color = SoomjaeTheme.colorScheme.comment,
+            )
+        }
+
+        SoomjaeVerticalDivider(
+            modifier = Modifier.height(height),
+            color = SoomjaeTheme.colorScheme.divider2,
+        )
+
+        Text(
+            text = createdAt,
+            style = SoomjaeTheme.typography.captionS,
+            color = SoomjaeTheme.colorScheme.text3,
+        )
+
+        SoomjaeVerticalDivider(
+            modifier = Modifier.height(height),
+            color = SoomjaeTheme.colorScheme.divider2,
+        )
+
+        Text(
+            text = author,
+            style = SoomjaeTheme.typography.captionS,
+            color = SoomjaeTheme.colorScheme.text3,
+        )
+    }
+}

--- a/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/models/MeetingPostUi.kt
+++ b/features/posts/meeting/presentation/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/presentation/tab/models/MeetingPostUi.kt
@@ -1,0 +1,38 @@
+package com.parksupark.soomjae.features.posts.common.presentation.tab.models
+
+import androidx.compose.runtime.Composable
+import com.parksupark.soomjae.core.presentation.ui.utils.toRelativeTimeString
+import com.parksupark.soomjae.features.posts.common.domain.models.MeetingPost
+import com.parksupark.soomjae.features.posts.common.presentation.models.AuthorUi
+import com.parksupark.soomjae.features.posts.common.presentation.models.CategoryUi
+import com.parksupark.soomjae.features.posts.common.presentation.models.toUi
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+@OptIn(ExperimentalTime::class)
+internal data class MeetingPostUi(
+    val id: Long,
+    val title: String,
+    val content: String,
+    val createdAt: Instant,
+    val author: AuthorUi,
+    val likeCount: Int,
+    val commentCount: Int,
+    val category: CategoryUi,
+) {
+    val formattedCreatedAt: String
+        @Composable get() = createdAt.toRelativeTimeString()
+}
+
+// TODO: implement likeCount and commentCount
+@ExperimentalTime
+internal fun MeetingPost.toMeetingPostUi() = MeetingPostUi(
+    id = id,
+    title = title,
+    content = content,
+    createdAt = createdAt,
+    author = author.toUi(),
+    likeCount = 0,
+    commentCount = 0,
+    category = category.toUi(),
+)


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

### ui
- add sp to dp conversion utility

### meeting post
- add meeting post data class and ui model
- add meeting post card components

### posts
- add write post fab and apply to community tab

## Does this close any currently open issues?

…

## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
...

## Any other comments?

…
