### PR TITLE
fix(meeting): update comment routes for meeting posts

### DIFF
--- a/features/posts/meeting/data/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/data/repositories/DefaultMeetingCommentRepository.kt
+++ b/features/posts/meeting/data/src/commonMain/kotlin/com/parksupark/soomjae/features/posts/common/data/repositories/DefaultMeetingCommentRepository.kt
@@ -17,7 +17,7 @@ internal class DefaultMeetingCommentRepository(
         postId: Long,
         content: String,
     ): Either<DataFailure, Comment> = httpClient.get<AddCommentResponse>(
-        route = "/v1/boards/community/posts/$postId/comments",
+        route = "/v1/boards/meeting/posts/$postId/comments",
     ).map { response ->
         response.toComment()
     }
@@ -26,6 +26,6 @@ internal class DefaultMeetingCommentRepository(
         postId: Long,
         commentID: Long,
     ): Either<DataFailure, Unit> = httpClient.delete<Unit>(
-        route = "/v1/boards/community/posts/$postId/comments/$commentID",
+        route = "/v1/boards/meeting/posts/$postId/comments/$commentID",
     )
 }


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.

### posts

- fix(meeting): update comment routes for meeting posts

## Does this close any currently open issues?

…

## Any relevant logs, error output, etc?

<!-- If it’s long, please paste to https://gist.github.com/ and insert the link here. -->
...

## Any other comments?

…
